### PR TITLE
Added territorial behaviours (Behaviours 5)

### DIFF
--- a/assets/behaviors/creatures/territorialCritter.behavior
+++ b/assets/behaviors/creatures/territorialCritter.behavior
@@ -1,0 +1,41 @@
+{
+  "selector": [
+    {
+      "guard": {
+        "componentPresent": "BehaviorsBasic:TerritoryDistance",
+        "values": ["V distanceSquared < 25"],
+        "child": {
+          "selector": [
+            {
+              "guard": {
+                "componentPresent": "Behaviors:FindNearbyPlayers",
+                "values": ["N charactersWithinRange nonEmpty"],
+                "child": {
+                    "sequence": [
+                      "set_target_nearby_player",
+                      {
+                        "lookup": {
+                          "tree": "Behaviors:hostile"
+                        }
+                      }
+                   ]
+                }
+              }
+            },
+            {
+              "lookup": {
+                "tree": "Behaviors:stray"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sequence": [
+        "set_target_territory",
+        "move_to"
+      ]
+    }
+  ]
+}

--- a/assets/groups/territorial.group
+++ b/assets/groups/territorial.group
@@ -1,0 +1,5 @@
+{
+  "groupLabel": "territorial",
+  "needsHive": "false",
+  "behavior": "Behaviors:territorialCritter"
+}

--- a/assets/prefabs/creatures/territorialDeer.prefab
+++ b/assets/prefabs/creatures/territorialDeer.prefab
@@ -1,0 +1,102 @@
+{
+  "skeletalmesh": {
+    "mesh": "deer",
+    "heightOffset": -0.8,
+    "material": "deerSkin",
+    "animation": "deerIdle",
+    "loop": true
+  },
+  "TerritoryDistance": {
+  },
+  "GroupTag" : {
+    "groups" : [ "territorial" ]
+  },
+  "Behavior": {
+    "tree": "BehaviorsBasic:territorialCritter"
+  },
+  "FindNearbyPlayers": {
+    "searchRadius": 5
+  },
+  "AttackOnHit": {
+    "minDistance": 5
+  },
+  "BlockDropGrammar": {
+    "blockDrops": [],
+    "itemDrops": [
+      "2*WildAnimals:meat"
+    ]
+  },
+  "Stand": {
+    "animationPool": [
+      "deerIdle",
+      "deerIdle",
+      "deerIdle",
+      "deerIdleLookLeft",
+      "deerIdleLookRight",
+      "deerIdleMoveLegs"
+    ]
+  },
+  "Walk": {
+    "animationPool": [
+      "deerWalk"
+    ]
+  },
+  "Die": {
+    "animationPool": [
+      "deerFall"
+    ]
+  },
+  "persisted": true,
+  "location": {},
+  "Character": {},
+  "AliveCharacter": {},
+  "WildAnimal": {
+    "name": "Deer",
+    "icon": "WildAnimals:deerIcon"
+  },
+  "NPCMovement": {},
+  "CreatureNameGenerator": {
+    "genderRatio": 0,
+    "nobility": 0,
+    "theme": "ANIMAL"
+  },
+  "CharacterMovement": {
+    "groundFriction": 16,
+    "speedMultiplier": 0.3,
+    "distanceBetweenFootsteps": 0.2,
+    "distanceBetweenSwimStrokes": 2.5,
+    "height": 1.6,
+    "radius": 0.3,
+    "jumpSpeed": 12
+  },
+  "CharacterSound": {
+    "footstepSounds": [
+      "FootGrass1",
+      "FootGrass2",
+      "FootGrass3",
+      "FootGrass4",
+      "FootGrass5"
+    ],
+    "footstepVolume": 0.03
+  },
+  "Network": {},
+  "MinionMove": {},
+  "Health": {
+    "destroyEntityOnNoHealth": true,
+    "currentHealth": 50,
+    "maxHealth": 50
+  },
+  "BoxShape": {
+    "extents": [
+      1.5,
+      1.5,
+      1.5
+    ]
+  },
+  "Trigger": {
+    "detectGroups": [
+      "engine:debris",
+      "engine:sensor"
+    ]
+  }
+}

--- a/assets/prefabs/creatures/territorialWolf.prefab
+++ b/assets/prefabs/creatures/territorialWolf.prefab
@@ -1,0 +1,94 @@
+{
+  "skeletalmesh": {
+    "mesh": "wolf",
+    "heightOffset": -0.8,
+    "material": "wolfSkin",
+    "animation": "wolfIdle",
+    "loop": true
+  },
+  "TerritoryDistance": {
+  },
+  "GroupTag" : {
+    "groups" : [ "territorial" ]
+  },
+  "Behavior": {
+    "tree": "BehaviorsBasic:territorialCritter"
+  },
+  "FindNearbyPlayers": {
+    "searchRadius": 5
+  },
+  "AttackOnHit": {
+    "minDistance": 5
+  },
+  "BlockDropGrammar": {
+    "blockDrops": [],
+    "itemDrops": [
+      "2*WildAnimals:meat"
+    ]
+  },
+  "Stand": {
+    "animationPool": [
+    ]
+  },
+  "Walk": {
+    "animationPool": [
+    ]
+  },
+  "Die": {
+    "animationPool": [
+    ]
+  },
+  "persisted": true,
+  "location": {},
+  "Character": {},
+  "AliveCharacter": {},
+  "WildAnimal": {
+    "name": "Wolf",
+    "icon": "WildAnimalsMadness:wolfIcon"
+  },
+  "NPCMovement": {},
+  "CreatureNameGenerator": {
+    "genderRatio": 0,
+    "nobility": 0,
+    "theme": "ANIMAL"
+  },
+  "CharacterMovement": {
+    "groundFriction": 16,
+    "speedMultiplier": 0.3,
+    "distanceBetweenFootsteps": 0.2,
+    "distanceBetweenSwimStrokes": 2.5,
+    "height": 1.6,
+    "radius": 0.3,
+    "jumpSpeed": 12
+  },
+  "CharacterSound": {
+    "footstepSounds": [
+      "FootGrass1",
+      "FootGrass2",
+      "FootGrass3",
+      "FootGrass4",
+      "FootGrass5"
+    ],
+    "footstepVolume": 0.03
+  },
+  "Network": {},
+  "MinionMove": {},
+  "Health": {
+    "destroyEntityOnNoHealth": true,
+    "currentHealth": 50,
+    "maxHealth": 50
+  },
+  "BoxShape": {
+    "extents": [
+      1.5,
+      1.5,
+      1.5
+    ]
+  },
+  "Trigger": {
+    "detectGroups": [
+      "engine:debris",
+      "engine:sensor"
+    ]
+  }
+}

--- a/src/main/java/org/terasology/behaviorsBasic/actions/SetTargetToNearbyPlayer.java
+++ b/src/main/java/org/terasology/behaviorsBasic/actions/SetTargetToNearbyPlayer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviorsBasic.actions;
+
+import org.terasology.behaviors.components.AttackOnHitComponent;
+import org.terasology.behaviors.components.FindNearbyPlayersComponent;
+import org.terasology.behaviors.components.FollowComponent;
+import org.terasology.engine.Time;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.registry.In;
+
+@BehaviorAction(name = "set_target_nearby_player")
+public class SetTargetToNearbyPlayer extends BaseAction {
+    @In
+    private Time time;
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        if (!actor.hasComponent(AttackOnHitComponent.class) || !actor.hasComponent(FindNearbyPlayersComponent.class)) {
+            return BehaviorState.FAILURE;
+        }
+
+        AttackOnHitComponent attackOnHitComponent = actor.getComponent(AttackOnHitComponent.class);
+        attackOnHitComponent.instigator = actor.getComponent(FindNearbyPlayersComponent.class).closestCharacter;
+        attackOnHitComponent.timeWhenHit = time.getGameTimeInMs();
+        actor.save(attackOnHitComponent);
+
+        FollowComponent followComponent = new FollowComponent();
+        followComponent.entityToFollow = attackOnHitComponent.instigator;
+        actor.getEntity().addOrSaveComponent(followComponent);
+
+        return BehaviorState.SUCCESS;
+    }
+}

--- a/src/main/java/org/terasology/behaviorsBasic/actions/SetTargetToTerritory.java
+++ b/src/main/java/org/terasology/behaviorsBasic/actions/SetTargetToTerritory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviorsBasic.actions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.behaviorsBasic.components.TerritoryDistance;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.minion.move.MinionMoveComponent;
+
+@BehaviorAction(name = "set_target_territory")
+public class SetTargetToTerritory extends BaseAction {
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        if (!actor.hasComponent(TerritoryDistance.class) || !actor.hasComponent(MinionMoveComponent.class)) {
+            return BehaviorState.FAILURE;
+        }
+
+        Vector3f territory = actor.getComponent(TerritoryDistance.class).location;
+
+        MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
+        if (moveComponent.target.equals(territory)) {
+            return BehaviorState.SUCCESS;
+        }
+
+        moveComponent.target = territory;
+        actor.save(moveComponent);
+
+        return BehaviorState.SUCCESS;
+    }
+}

--- a/src/main/java/org/terasology/behaviorsBasic/components/TerritoryDistance.java
+++ b/src/main/java/org/terasology/behaviorsBasic/components/TerritoryDistance.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviorsBasic.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+
+public class TerritoryDistance implements Component {
+    public float distanceSquared;
+    public Vector3f location;
+}

--- a/src/main/java/org/terasology/behaviorsBasic/system/InitialBehaviorSystem.java
+++ b/src/main/java/org/terasology/behaviorsBasic/system/InitialBehaviorSystem.java
@@ -61,7 +61,7 @@ public class InitialBehaviorSystem extends BaseComponentSystem {
         for (EntityRef entityRef : entityManager.getEntitiesWith(WildAnimalComponent.class, BehaviorComponent.class)) {
             logger.info("Assigning behavior to a wild animal based on the following prefab: " + entityRef.getParentPrefab().getName());
             assignBehaviorToEntity(entityRef, behavior);
-            logger.info("Behavior assigned:" + behavior);
+            logger.info("Behavior assigned: " + behavior);
         }
         return "All wild animals should have the same behavior now.";
     }
@@ -69,7 +69,7 @@ public class InitialBehaviorSystem extends BaseComponentSystem {
     @Command(shortDescription = "Assigns wild animals in the \"territorial\" group the behavior \"territorialCritter\".")
     public String assignGroupBehavior() {
         String group = "territorial";
-        String behavior = "BehaviorsBasic:territorialCritter";
+        String behavior = "Behaviors:critter";
         for (EntityRef entityRef : entityManager.getEntitiesWith(WildAnimalComponent.class, GroupTagComponent.class, BehaviorComponent.class)) {
             GroupTagComponent groupTag = entityRef.getComponent(GroupTagComponent.class);
             if (!groupTag.groups.contains(group)) {
@@ -81,11 +81,11 @@ public class InitialBehaviorSystem extends BaseComponentSystem {
             BehaviorComponent behaviorComponent = entityRef.getComponent(BehaviorComponent.class);
             groupTag.backupBT = behaviorComponent.tree;
             groupTag.backupRunningState = new Interpreter(behaviorComponent.interpreter);
-            entityRef.saveComponent(behaviorComponent);
+            entityRef.saveComponent(groupTag);
 
             assignBehaviorToEntity(entityRef, behavior);
 
-            logger.info("Behavior assigned:" + behavior);
+            logger.info("Behavior assigned: " + behavior);
         }
         return "All the animals in the group should have the same behavior now.";
     }

--- a/src/main/java/org/terasology/behaviorsBasic/system/InitialBehaviorSystem.java
+++ b/src/main/java/org/terasology/behaviorsBasic/system/InitialBehaviorSystem.java
@@ -70,7 +70,7 @@ public class InitialBehaviorSystem extends BaseComponentSystem {
     public String assignGroupBehavior() {
         String group = "territorial";
         String behavior = "Behaviors:critter";
-        for (EntityRef entityRef : entityManager.getEntitiesWith(WildAnimalComponent.class, GroupTagComponent.class, BehaviorComponent.class)) {
+        for (EntityRef entityRef : entityManager.getEntitiesWith(WildAnimalComponent.class, GroupTagComponent.class)) {
             GroupTagComponent groupTag = entityRef.getComponent(GroupTagComponent.class);
             if (!groupTag.groups.contains(group)) {
                 continue;
@@ -78,10 +78,12 @@ public class InitialBehaviorSystem extends BaseComponentSystem {
 
             logger.info("Assigning behavior to a wild animal based on the following prefab: " + entityRef.getParentPrefab().getName());
 
-            BehaviorComponent behaviorComponent = entityRef.getComponent(BehaviorComponent.class);
-            groupTag.backupBT = behaviorComponent.tree;
-            groupTag.backupRunningState = new Interpreter(behaviorComponent.interpreter);
-            entityRef.saveComponent(groupTag);
+            if (entityRef.hasComponent(BehaviorComponent.class)) {
+                BehaviorComponent behaviorComponent = entityRef.getComponent(BehaviorComponent.class);
+                groupTag.backupBT = behaviorComponent.tree;
+                groupTag.backupRunningState = new Interpreter(behaviorComponent.interpreter);
+                entityRef.saveComponent(groupTag);
+            }
 
             assignBehaviorToEntity(entityRef, behavior);
 
@@ -102,7 +104,7 @@ public class InitialBehaviorSystem extends BaseComponentSystem {
             behaviorComponent.interpreter = new Interpreter(new Actor(entityRef));
             behaviorComponent.interpreter.setTree(newBehaviorTree);
 
-            entityRef.saveComponent(behaviorComponent);
+            entityRef.addOrSaveComponent(behaviorComponent);
         }
     }
 }

--- a/src/main/java/org/terasology/behaviorsBasic/system/InitialBehaviorSystem.java
+++ b/src/main/java/org/terasology/behaviorsBasic/system/InitialBehaviorSystem.java
@@ -24,12 +24,15 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.behavior.BehaviorComponent;
+import org.terasology.logic.behavior.GroupTagComponent;
 import org.terasology.logic.behavior.Interpreter;
 import org.terasology.logic.behavior.asset.BehaviorTree;
 import org.terasology.logic.behavior.core.Actor;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.registry.In;
 import org.terasology.wildAnimals.component.WildAnimalComponent;
+
+import java.util.Optional;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class InitialBehaviorSystem extends BaseComponentSystem {
@@ -52,37 +55,54 @@ public class InitialBehaviorSystem extends BaseComponentSystem {
      *
      * @return success message
      */
-    @Command(shortDescription = "Assigns the 'critter' behavior to all wild animals.")
+    @Command(shortDescription = "Assigns the \"territorialCritter\" behavior to all wild animals.")
     public String assignBehavior() {
-
-        String behavior = "Behaviors:critter";
-        for (EntityRef entityRef : entityManager.getEntitiesWith(WildAnimalComponent.class)) {
-
+        String behavior = "BehaviorsBasic:territorialCritter";
+        for (EntityRef entityRef : entityManager.getEntitiesWith(WildAnimalComponent.class, BehaviorComponent.class)) {
             logger.info("Assigning behavior to a wild animal based on the following prefab: " + entityRef.getParentPrefab().getName());
-
             assignBehaviorToEntity(entityRef, behavior);
-
             logger.info("Behavior assigned:" + behavior);
-
-
         }
         return "All wild animals should have the same behavior now.";
     }
 
+    @Command(shortDescription = "Assigns wild animals in the \"territorial\" group the behavior \"territorialCritter\".")
+    public String assignGroupBehavior() {
+        String group = "territorial";
+        String behavior = "BehaviorsBasic:territorialCritter";
+        for (EntityRef entityRef : entityManager.getEntitiesWith(WildAnimalComponent.class, GroupTagComponent.class, BehaviorComponent.class)) {
+            GroupTagComponent groupTag = entityRef.getComponent(GroupTagComponent.class);
+            if (!groupTag.groups.contains(group)) {
+                continue;
+            }
+
+            logger.info("Assigning behavior to a wild animal based on the following prefab: " + entityRef.getParentPrefab().getName());
+
+            BehaviorComponent behaviorComponent = entityRef.getComponent(BehaviorComponent.class);
+            groupTag.backupBT = behaviorComponent.tree;
+            groupTag.backupRunningState = new Interpreter(behaviorComponent.interpreter);
+            entityRef.saveComponent(behaviorComponent);
+
+            assignBehaviorToEntity(entityRef, behavior);
+
+            logger.info("Behavior assigned:" + behavior);
+        }
+        return "All the animals in the group should have the same behavior now.";
+    }
+
 
     private void assignBehaviorToEntity(EntityRef entityRef, String behavior) {
+        Optional<BehaviorTree> potentialBehaviorTree = assetManager.getAsset(behavior, BehaviorTree.class);
 
-        BehaviorTree newBehaviorTree = assetManager.getAsset(behavior, BehaviorTree.class).get();
-
-        if(null != newBehaviorTree) {
+        if (potentialBehaviorTree.isPresent()) {
             BehaviorComponent behaviorComponent = new BehaviorComponent();
 
+            BehaviorTree newBehaviorTree = potentialBehaviorTree.get();
             behaviorComponent.tree = newBehaviorTree;
             behaviorComponent.interpreter = new Interpreter(new Actor(entityRef));
             behaviorComponent.interpreter.setTree(newBehaviorTree);
 
             entityRef.saveComponent(behaviorComponent);
         }
-
     }
 }

--- a/src/main/java/org/terasology/behaviorsBasic/system/TerritorialBehaviourSystem.java
+++ b/src/main/java/org/terasology/behaviorsBasic/system/TerritorialBehaviourSystem.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviorsBasic.system;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.behaviorsBasic.components.TerritoryDistance;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.In;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class TerritorialBehaviourSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+    @In
+    public EntityManager entityManager;
+    private List<Vector3f> territories = new ArrayList<Vector3f>();
+    private Random random = new Random();
+    private static Logger logger = LoggerFactory.getLogger(TerritorialBehaviourSystem.class);
+
+    @Override
+    public void initialise() {
+        territories.clear();
+    }
+
+    /**
+     * Update function for the Component System, which is called each
+     * time the engine is updated.
+     *
+     * @param delta The time (in seconds) since the last engine update.
+     */
+    @Override
+    public void update(float delta) {
+        for (EntityRef entity : entityManager.getEntitiesWith(TerritoryDistance.class, LocationComponent.class)) {
+            TerritoryDistance territoryDistance = entity.getComponent(TerritoryDistance.class);
+            territoryDistance.distanceSquared = territoryDistance.location.distanceSquared(entity.getComponent(LocationComponent.class).getWorldPosition());
+            entity.saveComponent(territoryDistance);
+        }
+    }
+
+    @ReceiveEvent(components = {TerritoryDistance.class})
+    public void onCreatureSpawned(OnActivatedComponent event, EntityRef creature) {
+        TerritoryDistance territoryDistance = creature.getComponent(TerritoryDistance.class);
+        territoryDistance.location = creature.getComponent(LocationComponent.class).getWorldPosition();
+        creature.saveComponent(territoryDistance);
+    }
+}


### PR DESCRIPTION
#### Overview:
This pull request implements territorial behaviours, where a creature is hostile to all nearby players within its territory. The creature will not leave its territory when wandering or when chasing a player. A territory is defined as a location in space along with any blocks surrounding it within a 5-block radius (this is constant as the behaviour system does not appear to support comparing a variable against a variable). For now, a creature's territory is the location where they were loaded into the game from.

All of the sample territorial creatures belong to the `territorial` group.

#### Testing Instructions:
- Use the console commands `spawnPrefab territorialDeer` and `spawnPrefab territorialWolf` in different locations to spawn the initial creatures
- A player should approach one of the spawned creatures
- The creature should attempt to attack the player but will stop as soon as the player reaches a certain distance from the creature's spawn point
- Execute the command `assignGroupBehavior`
- The spawned creatures should still attack the player when approached

#### Notes:
Sometimes it may be necessary to jump when in front of a creature in order for it to attack a player.